### PR TITLE
ci: delete per-arch build-* tags from Docker Hub after manifest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -145,6 +145,31 @@ jobs:
           done <<< "${{ steps.tags.outputs.tags }}"
           docker buildx imagetools create "${TAG_ARGS[@]}" $SOURCES
 
+      - name: Delete per-arch build tags from Docker Hub
+        # The per-arch images already exist inside the manifest by digest;
+        # the build-amd64 / build-arm64 tags are only needed during this
+        # workflow and would otherwise show up as user-visible tags forever.
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        run: |
+          set -eu
+          JWT=$(curl -fsSL -X POST https://hub.docker.com/v2/users/login/ \
+              -H 'Content-Type: application/json' \
+              -d "{\"username\":\"${DOCKER_HUB_USERNAME}\",\"password\":\"${DOCKER_HUB_TOKEN}\"}" \
+              | python3 -c 'import json,sys;print(json.load(sys.stdin)["token"])')
+          for tag in build-amd64 build-arm64; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE \
+                -H "Authorization: JWT ${JWT}" \
+                "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${tag}/")
+            echo "DELETE ${tag} -> HTTP ${code}"
+            # 204 = success, 404 = already gone (also fine)
+            case "$code" in
+              204|404) ;;
+              *) echo "Unexpected response, failing"; exit 1 ;;
+            esac
+          done
+
       - name: Update Docker Hub description
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: peter-evans/dockerhub-description@v4


### PR DESCRIPTION
## Summary
Small follow-up to #4. The `manifest` job now deletes the temporary `build-amd64` / `build-arm64` tags from Docker Hub after `imagetools create` has consumed them — they were only used to feed the manifest assembly and would otherwise show up as user-visible tags on the public Hub page forever.

Done via the Docker Hub v2 API (`POST /v2/users/login/` for a JWT, then `DELETE /v2/repositories/<image>/tags/<tag>/`). 404 is treated as success so re-runs are idempotent.

The two stale `build-*` tags from the first publish were already cleaned up manually using the same API, so the Hub view is tidy in the meantime.

## Test plan
- [ ] PR build passes for both AMD64 and ARM64 (no Hub touch on PR — `push: false`).
- [ ] After merge, on the post-merge publish: the `manifest` job runs, pushes `latest`/`zm-1.38.1`/`YYYY.MM`, then the new cleanup step deletes `build-amd64` and `build-arm64`.
- [ ] Verify on https://hub.docker.com/r/nardo86/zoneminder/tags that no `build-*` tags appear.
- [ ] Confirm the multi-arch `latest` still resolves both architectures: `docker buildx imagetools inspect nardo86/zoneminder:latest` lists `linux/amd64` and `linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)