### PR TITLE
fix(ci): authenticate GH API call when resolving latest ZM version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,6 +30,11 @@ jobs:
     steps:
       - name: Resolve ZoneMinder version
         id: resolve
+        env:
+          # The default GITHUB_TOKEN is enough to lift us from the 60 req/h
+          # unauthenticated rate limit (which is what made the previous run
+          # silently fall back to ZM_FALLBACK_VERSION the day 1.38.2 dropped).
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -eux
           INPUT_VERSION="${{ github.event.inputs.zm_version }}"
@@ -38,7 +43,11 @@ jobs:
             VERSION="$INPUT_VERSION"
           else
             echo "Fetching latest ZoneMinder release from GitHub API"
-            VERSION=$(curl -fsSL https://api.github.com/repos/ZoneMinder/zoneminder/releases/latest | jq -r '.tag_name' || true)
+            VERSION=$(curl -fsSL \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                https://api.github.com/repos/ZoneMinder/zoneminder/releases/latest \
+                | jq -r '.tag_name' || true)
             if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
               echo "API lookup failed, using fallback ${ZM_FALLBACK_VERSION}"
               VERSION="${ZM_FALLBACK_VERSION}"


### PR DESCRIPTION
## What's broken
The `prepare` job's `curl` to \`/repos/ZoneMinder/zoneminder/releases/latest\` ran unauthenticated, which means it shared the GitHub API's **60 req/h-per-IP** unauthenticated rate limit. Hosted runners share IPs across many jobs, so this limit is often exhausted by the time our scheduled build runs.

When the API returned a 403, \`curl -fsSL\` swallowed the error, \`jq\` got nothing, and the fallback `ZM_FALLBACK_VERSION=1.38.1` was used — silently rebuilding the same version forever.

This caused [run 26510066496](https://github.com/Nardo86/zm-docker/actions/runs/26510066496) to build **1.38.1** even though [1.38.2 had been published hours earlier](https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.2) (a security release with multiple RCE / command-injection fixes).

## Fix
Pass the default `${{ github.token }}` as a Bearer header. That lifts the limit to **1000 req/h per repo** — plenty for one monthly cron and a handful of manual runs.

## Test plan
- [ ] Triggered an out-of-band \`workflow_dispatch\` with `zm_version=1.38.2` to publish the security release immediately while this PR is in flight — that build will land on Docker Hub regardless of this fix.
- [ ] After this PR merges, leave the next \`workflow_dispatch\` input empty and confirm the prepare step logs `Resolved ZoneMinder version: 1.38.2` (or whatever upstream's `releases/latest` returns at that moment).
- [ ] Confirm the cron run on the 1st of next month picks up new ZM versions on its own without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)